### PR TITLE
Fedora 40 build

### DIFF
--- a/src/rp2040/README.md
+++ b/src/rp2040/README.md
@@ -13,7 +13,7 @@ sudo apt install cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential
 ### Install the Pi Pico Toolchain (Fedora)
 ```
 sudo dnf groupinstall "Development tools"
-sudo dnf install cmake gcc-arm-linux-gnu arm-none-eabi-gcc-cs-c++ arm-none-eabi-gcc-cs arm-none-eabi-binutils arm-none-eabi-newlib
+sudo dnf install clang cmake gcc-arm-linux-gnu arm-none-eabi-gcc-cs-c++ arm-none-eabi-gcc-cs arm-none-eabi-binutils arm-none-eabi-newlib
 ```
 
 ### Download an install the Pi Pico SDK
@@ -101,7 +101,7 @@ The RP2040 is by default somewhat inconvenient to develop for
 as it has to be mounted manually as mass-storage to copy the
 uf2 file onto it.
 
-It's thus recommanded to use a second Pi-Pico as a SWD programmng
+It's thus recommended to use a second Pi-Pico as a SWD programming
 adapter. The details are explained in appendix A of
 [Getting started with Raspberry Pi Pico](https://datasheets.raspberrypi.com/pico/getting-started-with-pico.pdf) under section ```Debug with a second Pico```.
 

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -14,6 +14,7 @@
 #include <stdio.h>
 #include "pio_usb.h"
 #include "pico/multicore.h"
+#include "hardware/clocks.h"
 
 #include "../debug.h"
 #include "../config.h"


### PR DESCRIPTION
When compiling the firmware in a Fedora 40 container the following errors occured:

```
-- The CXX compiler identification is unknown
CMake Error at CMakeLists.txt:2 (project):
  No CMAKE_CXX_COMPILER could be found.

  Tell CMake where to find the compiler by setting either the environment
  variable "CXX" or the CMake cache entry CMAKE_CXX_COMPILER to the full path
  to the compiler, or to the compiler name if it is in the PATH.


-- Configuring incomplete, errors occurred!
make[2]: *** [pico-sdk/src/rp2_common/tinyusb/CMakeFiles/pioasmBuild.dir/build.make:101: pico-sdk/src/rp2_common/tinyusb/pioasm/src/pioasmBuild-stamp/pioasmBuild-configure] Error 1
make[1]: *** [CMakeFiles/Makefile2:2035: pico-sdk/src/rp2_common/tinyusb/CMakeFiles/pioasmBuild.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

Fixed by adding `clang` to the packages that have to be installed.

----

```
/tmp/fpga/FPGA-Companion/src/rp2040/mcu_hw.c:212:3: error: implicit declaration of function 'set_sys_clock_khz' [-Wimplicit-function-declaration]
  212 |   set_sys_clock_khz(120000, true);
      |   ^~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/fpga_companion.dir/build.make:90: CMakeFiles/fpga_companion.dir/mcu_hw.c.obj] Error 1
make[1]: *** [CMakeFiles/Makefile2:1797: CMakeFiles/fpga_companion.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

Fixed by adding `#include "hardware/clocks.h"` to `mcu_hw.c`.