### PR TITLE
USB Gamepad Paddle support for C64 and VIC20 core

### DIFF
--- a/config/c64.xml
+++ b/config/c64.xml
@@ -66,23 +66,27 @@
     <menu label="System">
       <list label="Joyport 1:" id="Q" default="7">
  <listentry label="Retro D9" value="0"/>
- <listentry label="USB #1" value="1"/>
- <listentry label="USB #2" value="2"/>
+ <listentry label="USB #1 Joy" value="1"/>
+ <listentry label="USB #2 Joy" value="2"/>
  <listentry label="NumPad" value="3"/>
- <listentry label="DualShock" value="4"/>
+ <listentry label="DualShock2" value="4"/>
  <listentry label="Mouse" value="5"/>
- <listentry label="Paddle" value="6"/>
- <listentry label="Off" value="7"/>
+ <listentry label="DS2 Paddle" value="6"/>
+ <listentry label="USB #1 Padd" value="7"/>
+ <listentry label="USB #2 Padd" value="8"/>
+ <listentry label="Off" value="9"/>
       </list>
       <list label="Joyport 2:" id="J" default="0">
  <listentry label="Retro D9" value="0"/>
- <listentry label="USB #1" value="1"/>
- <listentry label="USB #2" value="2"/>
+ <listentry label="USB #1 Joy" value="1"/>
+ <listentry label="USB #2 Joy" value="2"/>
  <listentry label="NumPad" value="3"/>
- <listentry label="DualShock" value="4"/>
+ <listentry label="DualShock2" value="4"/>
  <listentry label="Mouse" value="5"/>
- <listentry label="Paddle" value="6"/>
- <listentry label="Off" value="7"/>
+ <listentry label="DS2 Paddle" value="6"/>
+ <listentry label="USB #1 Padd" value="7"/>
+ <listentry label="USB #2 Padd" value="8"/>
+ <listentry label="Off" value="9"/>
       </list>
       <list label="REU 1750:" id="V" default="0">
  <listentry label="Off" value="0"/>
@@ -176,6 +180,11 @@
       <list label="Tape Sound:" id="I" default="1">
  <listentry label="Off" value="0"/>
  <listentry label="On" value="1"/>
+      </list>
+      <list label="RS232 port:" id="*" default="0">
+ <listentry label="Tang USB-C" value="0"/>
+ <listentry label="External" value="1"/>
+ <listentry label="reserved" value="2"/>
       </list>
  <button label="C1541 Reset" action="c1541_reset_hide"/>
  <button label="Cold Boot" action="cold_reset_hide"/>

--- a/config/vic20.xml
+++ b/config/vic20.xml
@@ -66,13 +66,15 @@
     <menu label="System">
       <list label="Joyport:" id="Q" default="7">
  <listentry label="Retro D9" value="0"/>
- <listentry label="USB #1" value="1"/>
- <listentry label="USB #2" value="2"/>
+ <listentry label="USB #1 Joy" value="1"/>
+ <listentry label="USB #2 Joy" value="2"/>
  <listentry label="NumPad" value="3"/>
- <listentry label="DualShock" value="4"/>
+ <listentry label="DualShock2" value="4"/>
  <listentry label="Mouse" value="5"/>
- <listentry label="Paddle" value="6"/>
- <listentry label="Off" value="7"/>
+ <listentry label="DS2 Paddle" value="6"/>
+ <listentry label="USB #1 Padd" value="7"/>
+ <listentry label="USB #2 Padd" value="8"/>
+ <listentry label="Off" value="9"/>
       </list>
       <list label="C1541 ROM:" id="D" default="1">
  <listentry label="Dolphin DOS" value="0"/>

--- a/src/core_c64.c
+++ b/src/core_c64.c
@@ -30,8 +30,8 @@ static const char main_form_c64[] =
 static const char system_form_c64[] =
   "System,0|2;"                         // return to form 0, entry 2
   // --------
-  "L,Joyport 1:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|Paddle|Off|USB #1 Padd|USB #2 Padd,Q;"
-  "L,Joyport 2:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|Paddle|Off|USB #1 Padd|USB #2 Padd,J;"
+  "L,Joyport 1:,Retro D9|USB #1 Joy|USB #2 Joy|NumPad|DualShock 2|Mouse|DS2 Paddle|USB #1 Padd|USB #2 Padd|Off,Q;"
+  "L,Joyport 2:,Retro D9|USB #1 Joy|USB #2 Joy|NumPad|DualShock 2|Mouse|DS2 Paddle|USB #1 Padd|USB #2 Padd|Off,J;"
   "L,REU 1750:,Off|On,V;"
   "L,c1541 ROM:,Dolphin DOS|CBM DOS|Speed DOS P|Jiffy DOS,D;"
   "L,Turbo mode:,Off|C128|Smart,X;"
@@ -49,6 +49,7 @@ static const char system_form_c64[] =
   "L,RS232 mode:,VIC-1011|UP9600|SwiftLnk DE|SwiftLnk DF|SwiftLnk D7,<;"
   "L,GeoRAM:,Off|On,#;"
   "L,Tape Sound:,Off|On,I;"
+	"L,RS232 connection:,Tang USB-C|External|reserved,*;"
   "B,C1541 Reset,Z;"
   "B,Cold Boot,B;"; 
 
@@ -102,6 +103,7 @@ menu_legacy_variable_t core_c64_variables[] = {
   { 'H', { 0 }},    // default SID Filter = default
   { '#', { 0 }},    // default GeoRAM = off
   { '<', { 0 }},    // default RS232 mode = standard
+  { '*', { 0 }},    // default RS232 connection = Tang USB-C
   { '\0',{ 0 }}
 };
 

--- a/src/core_c64.c
+++ b/src/core_c64.c
@@ -49,7 +49,7 @@ static const char system_form_c64[] =
   "L,RS232 mode:,VIC-1011|UP9600|SwiftLnk DE|SwiftLnk DF|SwiftLnk D7,<;"
   "L,GeoRAM:,Off|On,#;"
   "L,Tape Sound:,Off|On,I;"
-	"L,RS232 connection:,Tang USB-C|External|reserved,*;"
+	"L,RS232 port:,Tang USB-C|External|reserved,*;"
   "B,C1541 Reset,Z;"
   "B,Cold Boot,B;"; 
 

--- a/src/core_c64.c
+++ b/src/core_c64.c
@@ -30,12 +30,12 @@ static const char main_form_c64[] =
 static const char system_form_c64[] =
   "System,0|2;"                         // return to form 0, entry 2
   // --------
-  "L,Joyport 1:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|Paddle|Off,Q;"
-  "L,Joyport 2:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|Paddle|Off,J;"
+  "L,Joyport 1:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|Paddle|Off|USB #1 Padd|USB #2 Padd,Q;"
+  "L,Joyport 2:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|Paddle|Off|USB #1 Padd|USB #2 Padd,J;"
   "L,REU 1750:,Off|On,V;"
   "L,c1541 ROM:,Dolphin DOS|CBM DOS|Speed DOS P|Jiffy DOS,D;"
   "L,Turbo mode:,Off|C128|Smart,X;"
-	"L,Turbo speed:,2x|3x|4x,Y;"
+  "L,Turbo speed:,2x|3x|4x,Y;"
   "L,Video Std:,PAL|NTSC,E;"
   "L,Midi:,Off|Sequential|Passport|DATEL|Namesoft,N;"
   "L,Pause OSD:,Off|On,G;"

--- a/src/core_vic20.c
+++ b/src/core_vic20.c
@@ -33,7 +33,7 @@ static const char main_form_vic20[] =
 static const char system_form_vic20[] =
   "System,0|2;"                         // return to form 0, entry 2
   // --------
-  "L,Joyport:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|DS Paddle|Off|USB #1 Padd|USB #2 Padd,Q;" // Joystick port 1 mapping
+  "L,Joyport:,Retro D9|USB #1 Joy|USB #2 Joy|NumPad|DualShock 2|Mouse|DS2 Paddle|USB #1 Padd|USB #2 Padd|Off,Q;" // Joystick port 1 mapping
   "L,c1541 ROM:,Dolphin DOS|CBM DOS|Speed DOS P|Jiffy DOS,D;"  // c1541 compatibility
   "L,RAM $04 3K:,Off|On,U;"
   "L,RAM $20 8K:,Off|On,X;"

--- a/src/core_vic20.c
+++ b/src/core_vic20.c
@@ -33,7 +33,7 @@ static const char main_form_vic20[] =
 static const char system_form_vic20[] =
   "System,0|2;"                         // return to form 0, entry 2
   // --------
-  "L,Joyport:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|Paddle|Off,Q;" // Joystick port 1 mapping
+  "L,Joyport:,Retro D9|USB #1|USB #2|NumPad|DualShock|Mouse|DS Paddle|Off|USB #1 Padd|USB #2 Padd,Q;" // Joystick port 1 mapping
   "L,c1541 ROM:,Dolphin DOS|CBM DOS|Speed DOS P|Jiffy DOS,D;"  // c1541 compatibility
   "L,RAM $04 3K:,Off|On,U;"
   "L,RAM $20 8K:,Off|On,X;"

--- a/src/hid.c
+++ b/src/hid.c
@@ -264,8 +264,8 @@ void joystick_parse(const hid_report_t *report, struct hid_joystick_state_S *sta
     mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
     mcu_hw_spi_tx_u08(state->js_index);
     mcu_hw_spi_tx_u08(joy);
-    mcu_hw_spi_tx_u08((a[0]>> 8) & 0xff);
-    mcu_hw_spi_tx_u08((a[1]>> 8) & 0xff);
+    mcu_hw_spi_tx_u08(a[0]);
+    mcu_hw_spi_tx_u08(a[1]);
     mcu_hw_spi_end();
   }
 }

--- a/src/hid.c
+++ b/src/hid.c
@@ -264,8 +264,8 @@ void joystick_parse(const hid_report_t *report, struct hid_joystick_state_S *sta
     mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
     mcu_hw_spi_tx_u08(state->js_index);
     mcu_hw_spi_tx_u08(joy);
-    mcu_hw_spi_tx_u08(a[0]);
-    mcu_hw_spi_tx_u08(a[1]);
+    mcu_hw_spi_tx_u08((a[0]>> 8) & 0xff);
+    mcu_hw_spi_tx_u08((a[1]>> 8) & 0xff);
     mcu_hw_spi_end();
   }
 }

--- a/src/hid.c
+++ b/src/hid.c
@@ -264,6 +264,8 @@ void joystick_parse(const hid_report_t *report, struct hid_joystick_state_S *sta
     mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
     mcu_hw_spi_tx_u08(state->js_index);
     mcu_hw_spi_tx_u08(joy);
+    mcu_hw_spi_tx_u08(a[0]);
+    mcu_hw_spi_tx_u08(a[1]);
     mcu_hw_spi_end();
   }
 }

--- a/src/hid.c
+++ b/src/hid.c
@@ -255,17 +255,24 @@ void joystick_parse(const hid_report_t *report, struct hid_joystick_state_S *sta
   if(a[1] > 0xc0) joy |= 0x04;
   if(a[1] < 0x40) joy |= 0x08;
 
-  if(joy != state->last_state) {  
+  int ax = 0;
+  int ay = 0;
+  ax = a[0];
+  ay = a[1];
+
+  if((joy != state->last_state) || (ax != state->last_state_x) || (ay != state->last_state_y)) {
     state->last_state = joy;
-    usb_debugf("JOY%d: %02x", state->js_index, joy);
-  
+    state->last_state_x = ax;
+    state->last_state_y = ay;
+    usb_debugf("JOY%d: D %02x A0 %02x A1 %02x", state->js_index, joy, ax, ay);
+
     mcu_hw_spi_begin();
     mcu_hw_spi_tx_u08(SPI_TARGET_HID);
     mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
     mcu_hw_spi_tx_u08(state->js_index);
     mcu_hw_spi_tx_u08(joy);
-    mcu_hw_spi_tx_u08(a[0]);
-    mcu_hw_spi_tx_u08(a[1]);
+    mcu_hw_spi_tx_u08(ax);
+    mcu_hw_spi_tx_u08(ay);
     mcu_hw_spi_end();
   }
 }

--- a/src/hid.c
+++ b/src/hid.c
@@ -248,7 +248,14 @@ void joystick_parse(const hid_report_t *report, struct hid_joystick_state_S *sta
     if(buffer[report->joystick_mouse.button[i].byte_offset] & 
        report->joystick_mouse.button[i].bitmask)
       joy |= (0x10<<i);
-  
+
+  // ... and the eight extra buttons
+  unsigned char btn_extra = 0;
+  for(int i=4;i<12;i++)
+    if(buffer[report->joystick_mouse.button[i].byte_offset] & 
+      report->joystick_mouse.button[i].bitmask) 
+      btn_extra |= (1<<(i-4));
+
   // map directions to digital
   if(a[0] > 0xc0) joy |= 0x01;
   if(a[0] < 0x40) joy |= 0x02;
@@ -260,19 +267,24 @@ void joystick_parse(const hid_report_t *report, struct hid_joystick_state_S *sta
   ax = a[0];
   ay = a[1];
 
-  if((joy != state->last_state) || (ax != state->last_state_x) || (ay != state->last_state_y)) {
+  if((joy != state->last_state) || 
+     (ax != state->last_state_x) || 
+     (ay != state->last_state_y) || 
+     (btn_extra != state->last_state_btn_extra))  {
     state->last_state = joy;
     state->last_state_x = ax;
     state->last_state_y = ay;
-    usb_debugf("JOY%d: D %02x A0 %02x A1 %02x", state->js_index, joy, ax, ay);
+    state->last_state_btn_extra = btn_extra;
+    usb_debugf("JOY%d: D %02x A0 %02x A1 %02x B %02x", state->js_index, joy, ax, ay, btn_extra);
 
     mcu_hw_spi_begin();
     mcu_hw_spi_tx_u08(SPI_TARGET_HID);
     mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
     mcu_hw_spi_tx_u08(state->js_index);
     mcu_hw_spi_tx_u08(joy);
-    mcu_hw_spi_tx_u08(ax);
-    mcu_hw_spi_tx_u08(ay);
+    mcu_hw_spi_tx_u08(ax); // e.g. gamepad X
+    mcu_hw_spi_tx_u08(ay); // e.g. gamepad Y
+    mcu_hw_spi_tx_u08(btn_extra); // e.g. gamepad extra buttons
     mcu_hw_spi_end();
   }
 }

--- a/src/hid.h
+++ b/src/hid.h
@@ -18,6 +18,7 @@ struct hid_joystick_state_S {
   unsigned char js_index;
   unsigned char last_state_x;
   unsigned char last_state_y;
+  unsigned char last_state_btn_extra;
 };
 
 typedef union {

--- a/src/hid.h
+++ b/src/hid.h
@@ -16,6 +16,8 @@ struct hid_mouse_state_S {
 struct hid_joystick_state_S {
   unsigned char last_state;
   unsigned char js_index;
+  unsigned char last_state_x;
+  unsigned char last_state_y;
 };
 
 typedef union {


### PR DESCRIPTION
add Gamepad Sticks as Paddle (X ,Y) for C64 and VIC20  core
add Gamepad extra Buttons