### PR TITLE
PiPico xbox gamepad extra buttons and analog mode

### DIFF
--- a/src/bl616/mcu_hw.c
+++ b/src/bl616/mcu_hw.c
@@ -272,12 +272,14 @@ static void xbox_parse(struct xbox_info_S *xbox) {
 
   // the xbox controller sends the direction bits in exactly the
   // reversed order than we expect ...
-  unsigned char state =
+  unsigned char state = 0;
+  state =
     ((xbox->buffer[2] & 0x01)<<3) | ((xbox->buffer[2] & 0x02)<<1) |
     ((xbox->buffer[2] & 0x04)>>1) | ((xbox->buffer[2] & 0x08)>>3) |
     (xbox->buffer[3] & 0xf0);  // Y, X, B, A
   
-  unsigned char state_btn_extra = 
+  unsigned char state_btn_extra = 0;
+  state_btn_extra =
     (xbox->buffer[2] & 0xf0)>>4; // RT LT BACK START
 
   // build analog stick x,y
@@ -291,7 +293,7 @@ static void xbox_parse(struct xbox_info_S *xbox) {
     ax != xbox->last_state_x ||
     ay != xbox->last_state_y) {
 
-    usb_debugf("XBOX Joy%d: B %02x EB %02x X %d Y %d", xbox->js_index, state, state_btn_extra, ax, ay);
+    usb_debugf("XBOX Joy%d: B %02x EB %02x X %02x Y %02x", xbox->js_index, state, state_btn_extra, ax, ay);
 
     mcu_hw_spi_begin();
     mcu_hw_spi_tx_u08(SPI_TARGET_HID);

--- a/src/bl616/mcu_hw.c
+++ b/src/bl616/mcu_hw.c
@@ -272,14 +272,12 @@ static void xbox_parse(struct xbox_info_S *xbox) {
 
   // the xbox controller sends the direction bits in exactly the
   // reversed order than we expect ...
-  unsigned char state = 0;
-  state =
+  unsigned char state =
     ((xbox->buffer[2] & 0x01)<<3) | ((xbox->buffer[2] & 0x02)<<1) |
     ((xbox->buffer[2] & 0x04)>>1) | ((xbox->buffer[2] & 0x08)>>3) |
     (xbox->buffer[3] & 0xf0);  // Y, X, B, A
   
-  unsigned char state_btn_extra = 0;
-  state_btn_extra =
+  unsigned char state_btn_extra =
     (xbox->buffer[2] & 0xf0)>>4; // RT LT BACK START
 
   // build analog stick x,y

--- a/src/hid.c
+++ b/src/hid.c
@@ -76,9 +76,9 @@ static void kbd_num2joy(char state, unsigned char code) {
       mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
       mcu_hw_spi_tx_u08(0x80);  // report this as joystick 0x80 as js0-x are USB joysticks
       mcu_hw_spi_tx_u08(kbd_joy_state);
-      mcu_hw_spi_tx_u08(0);  // analog X
-      mcu_hw_spi_tx_u08(0);  // analog Y
-      mcu_hw_spi_tx_u08(0);  // extra buttons
+//      mcu_hw_spi_tx_u08(0);  // analog X
+//      mcu_hw_spi_tx_u08(0);  // analog Y
+//      mcu_hw_spi_tx_u08(0);  // extra buttons
       mcu_hw_spi_end();
       
       kbd_joy_state_last = kbd_joy_state;
@@ -307,9 +307,9 @@ void rii_joy_parse(const unsigned char *buffer) {
   mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
   mcu_hw_spi_tx_u08(0);  // Rii joystick always report as joystick 0
   mcu_hw_spi_tx_u08(b);
-  mcu_hw_spi_tx_u08(0);  // analog X
-  mcu_hw_spi_tx_u08(0);  // analog Y
-  mcu_hw_spi_tx_u08(0);  // extra buttons
+//  mcu_hw_spi_tx_u08(0);  // analog X
+//  mcu_hw_spi_tx_u08(0);  // analog Y
+//  mcu_hw_spi_tx_u08(0);  // extra buttons
   mcu_hw_spi_end();
 }
 

--- a/src/hid.c
+++ b/src/hid.c
@@ -76,6 +76,9 @@ static void kbd_num2joy(char state, unsigned char code) {
       mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
       mcu_hw_spi_tx_u08(0x80);  // report this as joystick 0x80 as js0-x are USB joysticks
       mcu_hw_spi_tx_u08(kbd_joy_state);
+      mcu_hw_spi_tx_u08(0);  // analog X
+      mcu_hw_spi_tx_u08(0);  // analog Y
+      mcu_hw_spi_tx_u08(0);  // extra buttons
       mcu_hw_spi_end();
       
       kbd_joy_state_last = kbd_joy_state;
@@ -275,7 +278,7 @@ void joystick_parse(const hid_report_t *report, struct hid_joystick_state_S *sta
     state->last_state_x = ax;
     state->last_state_y = ay;
     state->last_state_btn_extra = btn_extra;
-    usb_debugf("JOY%d: D %02x A0 %02x A1 %02x B %02x", state->js_index, joy, ax, ay, btn_extra);
+    usb_debugf("JOY%d: D %02x X %02x Y %02x EB %02x", state->js_index, joy, ax, ay, btn_extra);
 
     mcu_hw_spi_begin();
     mcu_hw_spi_tx_u08(SPI_TARGET_HID);

--- a/src/hid.c
+++ b/src/hid.c
@@ -304,6 +304,9 @@ void rii_joy_parse(const unsigned char *buffer) {
   mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
   mcu_hw_spi_tx_u08(0);  // Rii joystick always report as joystick 0
   mcu_hw_spi_tx_u08(b);
+  mcu_hw_spi_tx_u08(0);  // analog X
+  mcu_hw_spi_tx_u08(0);  // analog Y
+  mcu_hw_spi_tx_u08(0);  // extra buttons
   mcu_hw_spi_end();
 }
 

--- a/src/hid.c
+++ b/src/hid.c
@@ -76,9 +76,9 @@ static void kbd_num2joy(char state, unsigned char code) {
       mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
       mcu_hw_spi_tx_u08(0x80);  // report this as joystick 0x80 as js0-x are USB joysticks
       mcu_hw_spi_tx_u08(kbd_joy_state);
-//      mcu_hw_spi_tx_u08(0);  // analog X
-//      mcu_hw_spi_tx_u08(0);  // analog Y
-//      mcu_hw_spi_tx_u08(0);  // extra buttons
+      mcu_hw_spi_tx_u08(0);  // analog X
+      mcu_hw_spi_tx_u08(0);  // analog Y
+      mcu_hw_spi_tx_u08(0);  // extra buttons
       mcu_hw_spi_end();
       
       kbd_joy_state_last = kbd_joy_state;
@@ -307,9 +307,9 @@ void rii_joy_parse(const unsigned char *buffer) {
   mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
   mcu_hw_spi_tx_u08(0);  // Rii joystick always report as joystick 0
   mcu_hw_spi_tx_u08(b);
-//  mcu_hw_spi_tx_u08(0);  // analog X
-//  mcu_hw_spi_tx_u08(0);  // analog Y
-//  mcu_hw_spi_tx_u08(0);  // extra buttons
+  mcu_hw_spi_tx_u08(0);  // analog X
+  mcu_hw_spi_tx_u08(0);  // analog Y
+  mcu_hw_spi_tx_u08(0);  // extra buttons
   mcu_hw_spi_end();
 }
 

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -321,27 +321,26 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	    ((p->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER  )?0x01:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER )?0x02:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_BACK           )?0x04:0x00) |
-	    ((p->wButtons & XINPUT_GAMEPAD_START          )?0x08:0x00) |
-      ((0x0 & 0xf000) >> 8);
+	    ((p->wButtons & XINPUT_GAMEPAD_START          )?0x08:0x00);
 
 	  // build analog stick x,y state
       int16_t ax = p->sThumbLX;
       int16_t ay = p->sThumbLY;
 
       // submit if state has changed
-	  if(state != xbox_state[idx].state ||
-      state_btn_extra != xbox_state[idx].state_btn_extra ||
-      ax != xbox_state[idx].state_x ||
-      ay != xbox_state[idx].state_y) {
-	    usb_debugf("XBOX Joy%d: B %02x EB %02x X %d Y %d", xbox_state[idx].js_index, state, state_btn_extra, ax , ay );
+	  if((state != xbox_state[idx].state) ||
+      (state_btn_extra != xbox_state[idx].state_btn_extra) ||
+      (ax != xbox_state[idx].state_x) ||
+      (ay != xbox_state[idx].state_y)) {
+	    usb_debugf("XBOX Joy%d: B %02x EB %02x X %d Y %d", xbox_state[idx].js_index, state, state_btn_extra, ax >> 8, ay >> 8);
 
 	    mcu_hw_spi_begin();
 	    mcu_hw_spi_tx_u08(SPI_TARGET_HID);
 	    mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
 	    mcu_hw_spi_tx_u08(xbox_state[idx].js_index);
 	    mcu_hw_spi_tx_u08(state);
-	    mcu_hw_spi_tx_u08((uint8_t)(ax >> 8)); // gamepad analog X
-	    mcu_hw_spi_tx_u08((uint8_t)(ay >> 8)); // gamepad analog Y
+	    mcu_hw_spi_tx_u08(ax >> 8); // gamepad analog X
+	    mcu_hw_spi_tx_u08(ay >> 8); // gamepad analog Y
 	    mcu_hw_spi_tx_u08(state_btn_extra); // gamepad extra buttons
 	    mcu_hw_spi_end();
 
@@ -368,9 +367,9 @@ void tuh_xinput_mount_cb(uint8_t dev_addr, uint8_t instance, const xinputh_inter
     xbox_state[idx].dev_addr = dev_addr;
     xbox_state[idx].instance = instance;
     xbox_state[idx].state = 0xff;
-    xbox_state[idx].state_btn_extra = 0xff;
-    xbox_state[idx].state_x = 0xffff;
-    xbox_state[idx].state_y = 0xffff;
+    xbox_state[idx].state_btn_extra = 0x00;
+    xbox_state[idx].state_x = -1;
+    xbox_state[idx].state_y = -1;
     xbox_state[idx].js_index = hid_allocate_joystick();
   } else
     usb_debugf("Error, no more free XBOX entries");

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -332,22 +332,22 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
       (state_btn_extra != xbox_state[idx].state_btn_extra) ||
       (ax != xbox_state[idx].state_x) ||
       (ay != xbox_state[idx].state_y)) {
-	    usb_debugf("XBOX Joy%d: B %02x EB %02x X %02x Y %02x", xbox_state[idx].js_index, state, state_btn_extra, ax >> 8, ay >> 8);
+
+      xbox_state[idx].state = state;
+      xbox_state[idx].state_btn_extra = state_btn_extra;
+      xbox_state[idx].state_x = ax;
+      xbox_state[idx].state_y = ay;
+      usb_debugf("XBOX Joy%d: B %02x EB %02x X %02x Y %02x", xbox_state[idx].js_index, state, state_btn_extra, byteScaleAnalog(ax), byteScaleAnalog(ay));
 
 	    mcu_hw_spi_begin();
 	    mcu_hw_spi_tx_u08(SPI_TARGET_HID);
 	    mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
 	    mcu_hw_spi_tx_u08(xbox_state[idx].js_index);
 	    mcu_hw_spi_tx_u08(state);
-	    mcu_hw_spi_tx_u08(ax >> 8); // gamepad analog X
-	    mcu_hw_spi_tx_u08(ay >> 8); // gamepad analog Y
+	    mcu_hw_spi_tx_u08(byteScaleAnalog(ax)); // gamepad analog X
+	    mcu_hw_spi_tx_u08(byteScaleAnalog(ay)); // gamepad analog Y
 	    mcu_hw_spi_tx_u08(state_btn_extra); // gamepad extra buttons
 	    mcu_hw_spi_end();
-	    
-	    xbox_state[idx].state = state;
-      xbox_state[idx].state_btn_extra = state_btn_extra;
-      xbox_state[idx].state_x = ax;
-      xbox_state[idx].state_y = ay;
     }
 	}
       }
@@ -476,4 +476,13 @@ void mcu_hw_main_loop(void) {
      http://www.freertos.org/a00111.html. */
 
   for( ;; );
+}
+
+uint8_t byteScaleAnalog(int16_t xbox_val)
+{
+  // Scale the xbox value from [-32768, 32767] to [1, 255]
+  // Offset by 32768 to get in range [0, 65536], then divide by 256 to get in range [1, 255]
+  uint8_t scale_val = (xbox_val + 32768) / 256;
+  if (scale_val == 0) return 1;
+  return scale_val;
 }

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -310,9 +310,13 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_DOWN )?0x04:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_LEFT )?0x02:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_RIGHT)?0x01:0x00) |
-	    ((p->wButtons & 0xf000) >> 8);
-	  
-	  // build extra button new state
+	    ((p->wButtons & XINPUT_GAMEPAD_A)         ?0x10:0x00) |
+	    ((p->wButtons & XINPUT_GAMEPAD_B)         ?0x20:0x00) |
+	    ((p->wButtons & XINPUT_GAMEPAD_X)         ?0x80:0x00) |
+	    ((p->wButtons & XINPUT_GAMEPAD_Y)         ?0x40:0x00);
+//    ((p->wButtons & 0xf000) >> 8);
+
+// build extra button new state
 	  unsigned char state_btn_extra =
 	    ((p->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER  )?0x01:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER )?0x02:0x00) |
@@ -336,8 +340,8 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	    mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
 	    mcu_hw_spi_tx_u08(xbox_state[idx].js_index);
 	    mcu_hw_spi_tx_u08(state);
-	    mcu_hw_spi_tx_u08(ax); // gamepad analog X
-	    mcu_hw_spi_tx_u08(ay); // gamepad analog Y
+	    mcu_hw_spi_tx_u08((uint8_t)ax); // gamepad analog X
+	    mcu_hw_spi_tx_u08((uint8_t)ay); // gamepad analog Y
 	    mcu_hw_spi_tx_u08(state_btn_extra); // gamepad extra buttons
 	    mcu_hw_spi_end();
 
@@ -363,7 +367,10 @@ void tuh_xinput_mount_cb(uint8_t dev_addr, uint8_t instance, const xinputh_inter
     usb_debugf("Using XBOX entry %d", idx);
     xbox_state[idx].dev_addr = dev_addr;
     xbox_state[idx].instance = instance;
-    xbox_state[idx].state = 0xff;    
+    xbox_state[idx].state = 0xff;
+    xbox_state[idx].state_btn_extra = 0xff;
+    xbox_state[idx].state_x = 128;
+    xbox_state[idx].state_y = 128;
     xbox_state[idx].js_index = hid_allocate_joystick();
   } else
     usb_debugf("Error, no more free XBOX entries");

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -83,8 +83,8 @@ static struct {
   uint8_t instance;
   uint8_t js_index;
   uint8_t state;
-  uint8_t state_x;
-  uint8_t state_y;
+  int16_t state_x;
+  int16_t state_y;
   uint8_t state_btn_extra;
 } xbox_state[MAX_XBOX_DEVICES];
   
@@ -369,8 +369,8 @@ void tuh_xinput_mount_cb(uint8_t dev_addr, uint8_t instance, const xinputh_inter
     xbox_state[idx].instance = instance;
     xbox_state[idx].state = 0xff;
     xbox_state[idx].state_btn_extra = 0xff;
-    xbox_state[idx].state_x = 128;
-    xbox_state[idx].state_y = 128;
+    xbox_state[idx].state_x = 0xffff;
+    xbox_state[idx].state_y = 0xffff;
     xbox_state[idx].js_index = hid_allocate_joystick();
   } else
     usb_debugf("Error, no more free XBOX entries");

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -325,8 +325,8 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
       ((0x0 & 0xf000) >> 8);
 
 	  // build analog stick x,y state
-	    int ax = p->sThumbLX;
-	    int ay = p->sThumbLY;
+      int16_t ax = p->sThumbLX;
+      int16_t ay = p->sThumbLY;
 
       // submit if state has changed
 	  if(state != xbox_state[idx].state ||
@@ -340,8 +340,8 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	    mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
 	    mcu_hw_spi_tx_u08(xbox_state[idx].js_index);
 	    mcu_hw_spi_tx_u08(state);
-	    mcu_hw_spi_tx_u08((uint8_t)ax); // gamepad analog X
-	    mcu_hw_spi_tx_u08((uint8_t)ay); // gamepad analog Y
+	    mcu_hw_spi_tx_u08((uint8_t)(ax >> 8)); // gamepad analog X
+	    mcu_hw_spi_tx_u08((uint8_t)(ay >> 8)); // gamepad analog Y
 	    mcu_hw_spi_tx_u08(state_btn_extra); // gamepad extra buttons
 	    mcu_hw_spi_end();
 

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -305,7 +305,8 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	if(xbox_state[idx].dev_addr == dev_addr && xbox_state[idx].instance == instance) {
       
 	  // build new state
-	  unsigned char state =
+	  unsigned char state = 0;
+    state =
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_UP   )?0x08:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_DOWN )?0x04:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_LEFT )?0x02:0x00) |
@@ -316,8 +317,9 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	    ((p->wButtons & XINPUT_GAMEPAD_Y)         ?0x40:0x00);
 //    ((p->wButtons & 0xf000) >> 8);
 
-// build extra button new state
-	  unsigned char state_btn_extra =
+    // build extra button new state
+	  unsigned char state_btn_extra = 0;
+    state_btn_extra =
 	    ((p->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER  )?0x01:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER )?0x02:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_BACK           )?0x04:0x00) |
@@ -327,12 +329,12 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
       int16_t ax = p->sThumbLX;
       int16_t ay = p->sThumbLY;
 
-      // submit if state has changed
+    // submit if state has changed
 	  if((state != xbox_state[idx].state) ||
       (state_btn_extra != xbox_state[idx].state_btn_extra) ||
       (ax != xbox_state[idx].state_x) ||
       (ay != xbox_state[idx].state_y)) {
-	    usb_debugf("XBOX Joy%d: B %02x EB %02x X %d Y %d", xbox_state[idx].js_index, state, state_btn_extra, ax >> 8, ay >> 8);
+	    usb_debugf("XBOX Joy%d: B %02x EB %02x X %02x Y %02x", xbox_state[idx].js_index, state, state_btn_extra, ax >> 8, ay >> 8);
 
 	    mcu_hw_spi_begin();
 	    mcu_hw_spi_tx_u08(SPI_TARGET_HID);
@@ -343,7 +345,7 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	    mcu_hw_spi_tx_u08(ay >> 8); // gamepad analog Y
 	    mcu_hw_spi_tx_u08(state_btn_extra); // gamepad extra buttons
 	    mcu_hw_spi_end();
-
+	    
 	    xbox_state[idx].state = state;
       xbox_state[idx].state_btn_extra = state_btn_extra;
       xbox_state[idx].state_x = ax;
@@ -366,10 +368,10 @@ void tuh_xinput_mount_cb(uint8_t dev_addr, uint8_t instance, const xinputh_inter
     usb_debugf("Using XBOX entry %d", idx);
     xbox_state[idx].dev_addr = dev_addr;
     xbox_state[idx].instance = instance;
-    xbox_state[idx].state = 0xff;
-    xbox_state[idx].state_btn_extra = 0x00;
-    xbox_state[idx].state_x = -1;
-    xbox_state[idx].state_y = -1;
+    xbox_state[idx].state = 0;
+    xbox_state[idx].state_btn_extra = 0;
+    xbox_state[idx].state_x = 0;
+    xbox_state[idx].state_y = 0;
     xbox_state[idx].js_index = hid_allocate_joystick();
   } else
     usb_debugf("Error, no more free XBOX entries");

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -305,8 +305,7 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	if(xbox_state[idx].dev_addr == dev_addr && xbox_state[idx].instance == instance) {
       
 	  // build new state
-	  unsigned char state = 0;
-    state =
+    unsigned char state =
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_UP   )?0x08:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_DOWN )?0x04:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_LEFT )?0x02:0x00) |
@@ -318,8 +317,7 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 //    ((p->wButtons & 0xf000) >> 8);
 
     // build extra button new state
-	  unsigned char state_btn_extra = 0;
-    state_btn_extra =
+    unsigned char state_btn_extra =
 	    ((p->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER  )?0x01:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER )?0x02:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_BACK           )?0x04:0x00) |

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -319,18 +319,14 @@ void tuh_xinput_report_received_cb(uint8_t dev_addr, uint8_t instance, xinputh_i
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_DOWN )?0x04:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_LEFT )?0x02:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_DPAD_RIGHT)?0x01:0x00) |
-	    ((p->wButtons & XINPUT_GAMEPAD_A)         ?0x10:0x00) |
-	    ((p->wButtons & XINPUT_GAMEPAD_B)         ?0x20:0x00) |
-	    ((p->wButtons & XINPUT_GAMEPAD_X)         ?0x80:0x00) |
-	    ((p->wButtons & XINPUT_GAMEPAD_Y)         ?0x40:0x00);
-//    ((p->wButtons & 0xf000) >> 8);
+	    ((p->wButtons & 0xf000) >> 8);
 
     // build extra button new state
     unsigned char state_btn_extra =
 	    ((p->wButtons & XINPUT_GAMEPAD_LEFT_SHOULDER  )?0x01:0x00) |
 	    ((p->wButtons & XINPUT_GAMEPAD_RIGHT_SHOULDER )?0x02:0x00) |
-	    ((p->wButtons & XINPUT_GAMEPAD_BACK           )?0x04:0x00) |
-	    ((p->wButtons & XINPUT_GAMEPAD_START          )?0x08:0x00);
+	    ((p->wButtons & XINPUT_GAMEPAD_BACK           )?0x10:0x00) | // Rumblepad 2 / Dual Action compatibility
+	    ((p->wButtons & XINPUT_GAMEPAD_START          )?0x20:0x00);
 
 	  // build analog stick x,y state
       int16_t ax = p->sThumbLX;

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -102,6 +102,15 @@ static void pio_usb_task(__attribute__((unused)) void *parms) {
   }
 }
 
+uint8_t byteScaleAnalog(int16_t xbox_val)
+{
+  // Scale the xbox value from [-32768, 32767] to [1, 255]
+  // Offset by 32768 to get in range [0, 65536], then divide by 256 to get in range [1, 255]
+  uint8_t scale_val = (xbox_val + 32768) / 256;
+  if (scale_val == 0) return 1;
+  return scale_val;
+}
+
 void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_report, uint16_t desc_len) {
   // Interface protocol (hid_interface_protocol_enum_t)
   const char* protocol_str[] = { "None", "Keyboard", "Mouse" };
@@ -476,13 +485,4 @@ void mcu_hw_main_loop(void) {
      http://www.freertos.org/a00111.html. */
 
   for( ;; );
-}
-
-uint8_t byteScaleAnalog(int16_t xbox_val)
-{
-  // Scale the xbox value from [-32768, 32767] to [1, 255]
-  // Offset by 32768 to get in range [0, 65536], then divide by 256 to get in range [1, 255]
-  uint8_t scale_val = (xbox_val + 32768) / 256;
-  if (scale_val == 0) return 1;
-  return scale_val;
 }


### PR DESCRIPTION
add xinput gamepad device left stick analog mode and extra buttons for PiPico and bl616 firmware.
pipico fw working for A2600 core related to xinput gamepad.

M0S (bl616) xinput not testable as wired and wireless **clone controller** not working presently. 
