### PR TITLE
Bl616 analog stick

### DIFF
--- a/src/bl616/mcu_hw.c
+++ b/src/bl616/mcu_hw.c
@@ -245,8 +245,14 @@ static void xbox_parse(struct xbox_info_S *xbox) {
     ((wButtons & XINPUT_GAMEPAD_START          )?0x20:0x00);
 
   // build analog stick x,y state
-  int16_t sThumbLX = xbox->buffer[11] << 8 | xbox->buffer[10];
-  int16_t sThumbLY = xbox->buffer[13] << 8 | xbox->buffer[12];
+  int16_t sThumbLX = xbox->buffer[7] << 8 | xbox->buffer[6];
+  int16_t sThumbLY = xbox->buffer[9] << 8 | xbox->buffer[8];
+
+  // map analog stick directions to digital
+  if(byteScaleAnalog(sThumbLX) > (uint8_t) 0xc0) state |= 0x01;
+  if(byteScaleAnalog(sThumbLX) < (uint8_t) 0x40) state |= 0x02;
+  if(byteScaleAnalog(sThumbLY) > (uint8_t) 0xc0) state |= 0x08; //
+  if(byteScaleAnalog(sThumbLY) < (uint8_t) 0x40) state |= 0x04; //
 
   // submit if state has changed
   if(state != xbox->last_state ||

--- a/src/bl616/mcu_hw.c
+++ b/src/bl616/mcu_hw.c
@@ -247,12 +247,14 @@ static void xbox_parse(struct xbox_info_S *xbox) {
   // build analog stick x,y state
   int16_t sThumbLX = xbox->buffer[7] << 8 | xbox->buffer[6];
   int16_t sThumbLY = xbox->buffer[9] << 8 | xbox->buffer[8];
+  uint8_t ax = byteScaleAnalog(sThumbLX);
+  uint8_t ay = ~byteScaleAnalog(sThumbLY);
 
   // map analog stick directions to digital
-  if(byteScaleAnalog(sThumbLX) > (uint8_t) 0xc0) state |= 0x01;
-  if(byteScaleAnalog(sThumbLX) < (uint8_t) 0x40) state |= 0x02;
-  if(byteScaleAnalog(sThumbLY) > (uint8_t) 0xc0) state |= 0x08; //
-  if(byteScaleAnalog(sThumbLY) < (uint8_t) 0x40) state |= 0x04; //
+  if(ax > (uint8_t) 0xc0) state |= 0x01;
+  if(ax < (uint8_t) 0x40) state |= 0x02;
+  if(ay > (uint8_t) 0xc0) state |= 0x04;
+  if(ay < (uint8_t) 0x40) state |= 0x08;
 
   // submit if state has changed
   if(state != xbox->last_state ||
@@ -264,15 +266,15 @@ static void xbox_parse(struct xbox_info_S *xbox) {
     xbox->last_state_btn_extra = state_btn_extra;
     xbox->last_state_x = sThumbLX;
     xbox->last_state_y = sThumbLY;
-    usb_debugf("XBOX Joy%d: B %02x EB %02x X %02x Y %02x", xbox->js_index, state, state_btn_extra, byteScaleAnalog(sThumbLX), byteScaleAnalog(sThumbLY));
+    usb_debugf("XBOX Joy%d: B %02x EB %02x X %02x Y %02x", xbox->js_index, state, state_btn_extra, ax, ay);
 
     mcu_hw_spi_begin();
     mcu_hw_spi_tx_u08(SPI_TARGET_HID);
     mcu_hw_spi_tx_u08(SPI_HID_JOYSTICK);
     mcu_hw_spi_tx_u08(xbox->js_index);
     mcu_hw_spi_tx_u08(state);
-    mcu_hw_spi_tx_u08(byteScaleAnalog(sThumbLX)); // gamepad analog X
-    mcu_hw_spi_tx_u08(byteScaleAnalog(sThumbLY)); // gamepad analog Y
+    mcu_hw_spi_tx_u08(ax); // gamepad analog X
+    mcu_hw_spi_tx_u08(ay); // gamepad analog Y
     mcu_hw_spi_tx_u08(state_btn_extra); // gamepad extra buttons
     mcu_hw_spi_end();
   }


### PR DESCRIPTION
correct analog paddle mode up down direction
support of left stick as digital joystick 