### PR TITLE
Rp2040 xbox adjust

### DIFF
--- a/src/hid.c
+++ b/src/hid.c
@@ -265,10 +265,8 @@ void joystick_parse(const hid_report_t *report, struct hid_joystick_state_S *sta
   if(a[1] > 0xc0) joy |= 0x04;
   if(a[1] < 0x40) joy |= 0x08;
 
-  int ax = 0;
-  int ay = 0;
-  ax = a[0];
-  ay = a[1];
+  int ax = a[0];
+  int ay = a[1];
 
   if((joy != state->last_state) || 
      (ax != state->last_state_x) || 

--- a/src/hid.h
+++ b/src/hid.h
@@ -16,8 +16,8 @@ struct hid_mouse_state_S {
 struct hid_joystick_state_S {
   unsigned char last_state;
   unsigned char js_index;
-  unsigned char last_state_x;
-  unsigned char last_state_y;
+  int last_state_x;
+  int last_state_y;
   unsigned char last_state_btn_extra;
 };
 


### PR DESCRIPTION
xbox 360 controller support for BL616 / M0S Dock Firmware. Updated to make use of the CherryUSB 2.42 USB Stack

xbox 360 controller left stick mapped to digital direction for the RP2040 Firmware