### PR TITLE
Fix for USB HID devices initialization on rpi pico

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -15,7 +15,7 @@
 #endif
 
 #define MAX_DRIVES                   (8)
-#define MAX_HID_DEVICES              (4)
+#define MAX_HID_DEVICES              (6)
 #define MAX_XBOX_DEVICES             (2)
 
 

--- a/src/core_atarist.c
+++ b/src/core_atarist.c
@@ -34,6 +34,7 @@ static const char system_form[] =
   "L,Video:,Color|Mono,V;"
   "L,Cartridge:,None|Cubase 2&3,Q;"     // Cubase dongle support
   "L,Mouse:,USB|Atari ST|Amiga,J;"      // Mouse (DB9) mapping
+  "L,USB Joy:,Port1/Port0,Port0/Port1,U;" //USB Joys order
   "L,TOS Slot:,Primary|Secondary,T;"    // Select TOS
   "B,Cold Boot,B;";                     // system reset with memory reset
 
@@ -72,6 +73,7 @@ menu_legacy_variable_t core_atarist_variables[] = {
   { 'P', { 0 }},    // default no floppy write protected
   { 'Q', { 0 }},    // default cubase dongle not enabled
   { 'J', { 0 }},    // default mouse USB, DB9 connector joystick
+  { 'U', { 0 }},    // default Port1/Port0 assingned for USB Joys
   { 'T', { 0 }},    // default primary TOS slot
   { '\0',{ 0 }}
 };

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -203,14 +203,7 @@ void tuh_hid_mount_cb(uint8_t dev_addr, uint8_t instance, uint8_t const* desc_re
       hid_device[idx].dev_addr = dev_addr;
       hid_device[idx].instance = instance;
       if(hid_device[idx].rep.type == REPORT_TYPE_JOYSTICK)
-	hid_device[idx].state.joystick.js_index = hid_allocate_joystick();
-      else if(hid_device[idx].rep.type == REPORT_TYPE_MOUSE) {
-	// switch mice to report mode
-	if(!tuh_hid_set_protocol(dev_addr, instance, HID_PROTOCOL_REPORT)) {
-	  usb_debugf("Failed to set report mode");
-	  hid_device[idx].rep.report_id_present = false;
-	}
-      }
+	      hid_device[idx].state.joystick.js_index = hid_allocate_joystick();
     } else
       usb_debugf("Ignoring device");
   } else
@@ -870,6 +863,7 @@ void mcu_hw_init(void) {
   gpio_put(LED_JOYSTICK_PIN, 0);
 #endif
   
+  tuh_hid_set_default_protocol(HID_PROTOCOL_REPORT);
   tuh_init(BOARD_TUH_RHPORT);
   
   xTaskCreate(pio_usb_task, "usb_task", 2048, NULL, configMAX_PRIORITIES, NULL);


### PR DESCRIPTION
Fixes: MiSTle-Dev/MiSTeryNano#97

fix USB HID initialization. It's not allowed to change protocol while enumerating HID devices. It cause issue with Logitech universal dongle when enumeration stopped after second endpoint and from that point attach device stop working. 

Also increased MAX hid devices, because logitech universal dongle has 3 (2 HID and 1 unrecognized) + 2x gamepad.

Deinitialization of Logitech dongle still doesn't work, it looks like bug in tinyUSB, but at least initialization works as expected and doesn't cause issue with device order. Without fix when Logitech dongle was initialized first, nothing else was recognized, right now everything works and deinitialization of other devices works as well.