### PR TITLE
CMake: fix default BOARD

### DIFF
--- a/src/rp2040/CMakeLists.txt
+++ b/src/rp2040/CMakeLists.txt
@@ -25,7 +25,7 @@ message("==============================")
 
 # The BOARD option selects which board to build for
 # Regular Pico (W) by default
-option(BOARD "Board type. Can be PICO, PICO2, WS2040_ZERO or SH20KLITE" PICO)
+set(BOARD "PICO" CACHE STRING "Board type. Can be PICO, PICO2, WS2040_ZERO or SH20KLITE")
 
 set(BOARDS PICO PICO2 WS2040_ZERO SH20KLITE)
 if( NOT ${BOARD} IN_LIST BOARDS)


### PR DESCRIPTION
Fix: replace 'option' with string variable

'option' creates a boolean variable, which caused build error when no board was specified.

Reference:
https://stackoverflow.com/questions/8709877/cmake-string-options