### PR TITLE
onboard Bl616 fpga SRAM loader fix

### DIFF
--- a/src/bl616/README.md
+++ b/src/bl616/README.md
@@ -23,6 +23,8 @@ BL616 GPIO pin mapping is fix in SDK and no option to change. UART RX GPIO is bo
 |JTAG TDI     |GPIO3|SPI MOSI|  |
 |BL616 UART RX|GPIO x|SPI _IRQ    |  |
 |BL616 UART TX|GPIO x|V_JTAGSELN| 0=JTAG, 1=SPI |
+|BL616 TWI SCL*|GPIO x|UART TX| debug console |
+
 
 [Windows 11 Build AiO](#tang-onboard-bl616)
 

--- a/src/jtag.c
+++ b/src/jtag.c
@@ -300,11 +300,7 @@ void jtag_gowin_fpgaReset(void) {
 
     jtag_gowin_command(JTAG_COMMAND_GOWIN_RECONFIG);
     jtag_gowin_command(JTAG_COMMAND_GOWIN_NOOP);
-    // Run-Test-Idle state
-    mcu_hw_jtag_tms(1, 0b011, 3);
-    jtag_toggleClk(10000);
-    // Test-Logic-Reset state.
-    mcu_hw_jtag_tms(1, 0b11111, 5);
-    jtag_debugf("RECONFIG completed");
+    // RUN-TEST/IDLE
+    mcu_hw_jtag_tms(1, 0b000000, 6);
 }
 

--- a/src/mcu_hw.h
+++ b/src/mcu_hw.h
@@ -33,13 +33,9 @@ bool mcu_hw_tcp_data(unsigned char byte);
 
 // some boards provide a connection to the FPGAs JTAG interface
 #ifdef TANG_CONSOLE60K
-// 0 = FPGA , 1 = BL616
 #define PIN_TF_SDIO_SEL GPIO_PIN_16
-#elif TANG_NANO20K
-// dummy Nano20k unused pin
-#define PIN_TF_SDIO_SEL GPIO_PIN_17
 #endif
-#if defined(TANG_CONSOLE60K) || defined(TANG_NANO20K)
+#if defined(TANG_CONSOLE60K) || defined(TANG_NANO20K) || defined(TANG_MEGA138KPRO)
 void mcu_hw_jtag_set_pins(uint8_t dir, uint8_t data);
 uint8_t mcu_hw_jtag_tms(uint8_t tdi, uint8_t data, int len);
 void mcu_hw_jtag_data(uint8_t *txd, uint8_t *rxd, int len);

--- a/src/sysctrl.c
+++ b/src/sysctrl.c
@@ -280,7 +280,7 @@ static void sys_handle_event(bool ignore_coldboot) {
     else {
       sys_debugf("FPGA cold boot detected, reseting MCU ...");
 
-#if defined(TANG_CONSOLE60K) || defined(TANG_NANO20K) || (MISTLE_BOARD == 4)
+#if defined(TANG_CONSOLE60K)||defined(TANG_NANO20K)||defined(TANG_MEGA138KPRO)||defined(TANG_MEGA60K)||defined(TANG_PRIMER25K)||(MISTLE_BOARD == 4)
       // Check for USB-JTAG activity and don't reset (and thus break
       // the JTAG activity)
       if(mcu_hw_jtag_is_active())


### PR DESCRIPTION
BL616 Tang onboard MPU mass storage FPGA SRAM loader 
- FPGA SRAM loader for Console 60k / 138k **SDcard slot** and **USB memory stick**. SD served first
- FPGA SRAM loader for Nano 20k USB memory stick
- provision for all other Tang boards (USB) presently untested

**TN20K:** You need to press and keep Tang S2 button during power-up in order to invoke the loader in case no MiSTle blank image already burned to FLASH. USB pendrive need to contain core.bin (or core.fs)

**Console60K/138K:** You need to press and keeep Tang S1 button longer than 5sec pressed during power-up in order to invoke the loader in case no MiSTle blank image already burned to FLASH.
SD Card need to contain core.bin (or core.fs) or alternatively 
USB Stick need to contain core.bin (or core.fs)
> [!NOTE]
> Cores that support prevention of automatic FLASH load at power-up by keeping S1 button pressed are not yet in full scale released. As back-up you have to burn to FLASH [Console 60k MiSTle blank image](https://github.com/MiSTle-Dev/C64Nano/releases/download/v2.7.0/MiSTle_Console60k.bin). MiSTle-dev image will be shown for 5 sec and then core from mass storage loaded.
 
The ```.bin``` can be gerated from the ```.fs``` file using the gowin programmer in case not yet available.

```
programmer_cli --filestransform 1 --files C64Nano_Console60k.fs
```
rename output result to core.bin and copy to your SDcard

During download screen will blank. 
Release the Tang button !

load time for core in **binary format (core.bin)** from SDcard or USB pendrive
tn20k 0.83 sec 
tc60k 1.3 sec

Presently core.fs is not accelerated and it takes about 45sec to download.

for a build:
pull SDK update ! https://github.com/MiSTle-Dev/bouffalo_sdk/tree/cherryupd3
SDK was buggy related to USB fatfs operation

