### PR TITLE
PiPico MiSTeryShieldPicoTN20k FPGA loader

### DIFF
--- a/src/mcu_hw.h
+++ b/src/mcu_hw.h
@@ -83,6 +83,17 @@ void mcu_hw_jtag_toggleClk(uint32_t);
 // give file system driver in sdio.c access to the local sdio sd card
 #define SDIO_DIRECT_READ   sdio_sector_read
 #define SDIO_DIRECT_WRITE  sdio_sector_write
+#elif MISTLE_BOARD == 5
+// MiSTeryShield PiPico + TN20k + Rework (JTAG + RECONFIGn)
+void mcu_hw_jtag_set_pins(uint8_t dir, uint8_t data);
+uint8_t mcu_hw_jtag_tms(uint8_t tdi, uint8_t data, int len);
+void mcu_hw_jtag_data(uint8_t *txd, uint8_t *rxd, int len);
+void mcu_hw_fpga_reconfig(bool state);
+bool mcu_hw_jtag_is_active(void);
+void mcu_hw_jtag_toggleClk(uint32_t);
+
+#define ENABLE_JTAG
+#define FPGA_BOOT_TIMEOUT 5000    /* give FPGA 5 seconds to boot */
 #endif
 
 #endif

--- a/src/rp2040/CMakeLists.txt
+++ b/src/rp2040/CMakeLists.txt
@@ -28,9 +28,9 @@ set(PICO_BOARD pico_w CACHE STRING "Board type")
 
 # The BOARD option selects which board to build for
 # Regular Pico (W) by default
-set(BOARD PICO CACHE STRING "Board type. Can be PICO, PICO2, WS2040ZERO, SH20KLITE or DEV20K")
+set(BOARD PICO CACHE STRING "Board type. Can be PICO, PICO2, WS2040ZERO, SH20KLITE, DEV20K, MSP20K")
 
-set(BOARDS PICO PICO2 WS2040ZERO SH20KLITE DEV20K)
+set(BOARDS PICO PICO2 WS2040ZERO SH20KLITE DEV20K MSP20K)
 if( NOT BOARD IN_LIST BOARDS)
     message(FATAL_ERROR "BOARD must be one of ${BOARDS}")
 endif()
@@ -116,8 +116,14 @@ elseif(${BOARD} STREQUAL DEV20K)
    target_sources(${PROJECT} PRIVATE sdio.c ../jtag.c ../gowin.c usb_jtag.c)
    target_sources(${PROJECT} PRIVATE usb_descriptors.c)
    target_link_libraries(${PROJECT} PRIVATE tinyusb_device)
+elseif(${BOARD} STREQUAL MSP20K)
+   add_compile_definitions(${PROJECT} PRIVATE MISTLE_BOARD=5)
+   add_custom_command(TARGET ${PROJECT} POST_BUILD COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --cyan "Firmware has been built for MiSTeryShieldPicoTN20k.")
+   target_sources(${PROJECT} PRIVATE ../jtag.c ../gowin.c usb_jtag.c)
+   target_sources(${PROJECT} PRIVATE usb_descriptors.c)
+   target_link_libraries(${PROJECT} PRIVATE tinyusb_device)
 else()
-   message(FATAL_ERROR "BOARD must be PICO, PICO2, WS2040ZERO, SH20KLITE or DEV20K")
+   message(FATAL_ERROR "BOARD must be PICO, PICO2, WS2040ZERO, SH20KLITE, DEV20K or MSP20K")
 endif()
 
 target_include_directories(${PROJECT} PRIVATE

--- a/src/rp2040/README.md
+++ b/src/rp2040/README.md
@@ -159,11 +159,24 @@ On the regular Pico, the FPGA Companion uses the following pins:
 | GP4  | LED 1 | indicator mouse |
 | GP5  | LED 2 | indicator keyboard |
 | GP6  | LED 3 | indicator joystick |
+| GP12 [^a]  | TDI | JTAG TDI |
+| GP13 [^a]  | TMS | JTAG TMS |
+| GP14 [^a]  | TDO | JTAG TDO |
+| GP15 [^a]  | TCK | JTAG TCK |
 | GP16 | MISO | SPI data from FPGA |
 | GP17 | CSn | SPI chip select to FPGA |
 | GP18 | SCK | SPI clock to FPGA |
 | GP19 | MOSI | SPI data to FPGA |
+| GP21 [^b] | RECONFIGn | FPGA reload |
 | GP22 | IRQn | SPI interrupt from FPGA |
+| GP26 [^b] | MODE0 | FPGA mode 0 |
+| GP27 [^b] | MODE1 | FPGA mode 1 |
+
+If PiPico is used as JTAG loader the TANG20k onboard BL616 need to be disabled by connecting CHIP_EN to GND.
+
+
+[^a]: JTAG FPGA loader
+[^b]: JTAG FPGA loader, only for FLASH programming needed
 
 ## Using the internal micro USB connector
 

--- a/src/rp2040/mcu_hw.c
+++ b/src/rp2040/mcu_hw.c
@@ -46,7 +46,12 @@
 #warning "Building for MiSTeryDev20k"
 #include "../jtag.h"
 #include "./sdio.h"
-
+#elif MISTLE_BOARD == 5
+#warning "Building for MiSTeryShieldPicoTN20k"
+#define ENABLE_WIFI
+#include "../jtag.h"
+#endif
+#if MISTLE_BOARD == 4
 // FPGA JTAG pins
 #define PIN_JTAG_TDI  12   // pin 15, gpio 12
 #define PIN_JTAG_TMS  13   // pin 16, gpio 13
@@ -56,8 +61,18 @@
 // special FPGA configuration pins
 #define PIN_nCFG      21   // pin 32, PIO21
 #define PIN_MODE0     23   // pin 35, PIO23
-#define PIN_MODE1     24   // pin 36, PIO24
+#define PIN_MODE1     24   /* pin 36, PIO24 */
+#elif MISTLE_BOARD == 5
+// FPGA JTAG pins
+#define PIN_JTAG_TDI  12   // pin 15, gpio 12
+#define PIN_JTAG_TMS  13   // pin 16, gpio 13
+#define PIN_JTAG_TDO  14   // pin 17, gpio 14
+#define PIN_JTAG_TCK  15   // pin 18, gpio 15
 
+// special FPGA configuration pins
+#define PIN_nCFG      21   // pin 32, PIO21
+#define PIN_MODE0     26   // pin 31, PIO26
+#define PIN_MODE1     27   /* pin 32, PIO27 */
 #else
 #error "Not a supported MiSTle board!"
 #endif
@@ -152,7 +167,7 @@ static void pio_usb_task(__attribute__((unused)) void *parms) {
   while(1) {
     for(int i=0;i<100;i++) {
       tuh_task();
-#if MISTLE_BOARD == 4
+#if MISTLE_BOARD == 4 || MISTLE_BOARD == 5
       tud_task();
       usb_jtag_poll();
 #endif
@@ -1369,7 +1384,7 @@ void mcu_hw_init(void) {
   };
   tusb_init(BOARD_TUH_RHPORT, &host_init);
   
-#if MISTLE_BOARD == 4
+#if (MISTLE_BOARD == 4) || (MISTLE_BOARD == 5)
   tusb_rhport_init_t dev_init = {
     .role = TUSB_ROLE_DEVICE,
     .speed = TUSB_SPEED_AUTO

--- a/src/rp2040/tusb_config.h
+++ b/src/rp2040/tusb_config.h
@@ -58,7 +58,7 @@
 
 // the dev board implements a USB JTAG bridge
 
-#if MISTLE_BOARD == 4
+#if (MISTLE_BOARD == 4) || (MISTLE_BOARD == 5)
 #define JTAG_CHANNELS   2    // can be one or two
    
 // RHPort number used for device can be defined by board.mk, default to port 0

--- a/src/rp2040/usb_jtag.c
+++ b/src/rp2040/usb_jtag.c
@@ -10,7 +10,7 @@
 #include "../mcu_hw.h"
 #include "../debug.h"
 
-#if MISTLE_BOARD != 4
+#if MISTLE_BOARD != 4 && MISTLE_BOARD != 5
 #error "USB JTAG is only available for the Dev20k"
 #else
 #warning "Enabling USB JTAG bridge"

--- a/src/sysctrl.c
+++ b/src/sysctrl.c
@@ -269,7 +269,7 @@ static void sys_handle_event(bool ignore_coldboot) {
 
     // the second button controls the OSD, so it can be used in conjunction
     // with 
-#if defined(TANG_CONSOLE60K)||defined(TANG_NANO20K)||defined(TANG_MEGA138KPRO)||defined(TANG_MEGA60K)||defined(TANG_PRIMER25K)||(MISTLE_BOARD == 4)
+#if defined(TANG_CONSOLE60K)||defined(TANG_NANO20K)||defined(TANG_MEGA138KPRO)||defined(TANG_MEGA60K)||defined(TANG_PRIMER25K)||(MISTLE_BOARD == 4)||(MISTLE_BOARD == 5)
     if(!mcu_hw_jtag_is_active())
 #endif
 
@@ -284,7 +284,7 @@ static void sys_handle_event(bool ignore_coldboot) {
     else {
       sys_debugf("FPGA cold boot detected, reseting MCU ...");
 
-#if defined(TANG_CONSOLE60K)||defined(TANG_NANO20K)||defined(TANG_MEGA138KPRO)||defined(TANG_MEGA60K)||defined(TANG_PRIMER25K)||(MISTLE_BOARD == 4)
+#if defined(TANG_CONSOLE60K)||defined(TANG_NANO20K)||defined(TANG_MEGA138KPRO)||defined(TANG_MEGA60K)||defined(TANG_PRIMER25K)||(MISTLE_BOARD == 4)||(MISTLE_BOARD == 5)
       // Check for USB-JTAG activity and don't reset (and thus break
       // the JTAG activity)
       if(mcu_hw_jtag_is_active()) {


### PR DESCRIPTION
PiPico FPGA loader for MiSTReryShieldPiPico20k that need a extra few jumper wires (JTAG signals) in between TN20k PCBA top side and PiPico PCBA top side. 

* PiPico support of FPGA core load from USB pendrive (OSD shift F12) 

[TN20k PCBA testpoint](https://dl.sipeed.com/shareURL/TANG/Nano_20K/4_Dimensional_drawing/v3921) Tang_Nano_20K_3921_Demension.pdf
to PiPico (W) 


| GP12   | TDI | JTAG TDI |
| GP13   | TMS | JTAG TMS |
| GP14   | TDO | JTAG TDO |
| GP15   | TCK | JTAG TCK |

https://pip-assets.raspberrypi.com/categories/610-raspberry-pi-pico/documents/RP-008309-DS-1-Pico-R3-A4-Pinout.pdf

build target: MSP20K  (MiSTeryShieldPico)

Note: USB FLASH program might need S2 button press during power-up.

see also https://github.com/MiSTle-Dev/C64Nano/issues/200
